### PR TITLE
Fix a crash when using custom skill that does not have the hard coded knowledge skills

### DIFF
--- a/src/scripts/hud-builder.js
+++ b/src/scripts/hud-builder.js
@@ -392,6 +392,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 }
 
                 const knowledges = this.#knowledgeSkillIds
+                    .filter((id) => actorSkills[id])
                     .filter((id) => !Settings.hideUntrainedSkills || !actorSkills[id].rt || !!actorSkills[id].rank)
                     .map((id) => ({
                         id: `categorized-${id}`,


### PR DESCRIPTION
I am using consolidated skills in my game and wrote a small module that changes the default actor skills in PF1 (https://github.com/ymgeva/ymg-pathfinder)
This caused a crash in Token Action Hud because the hard-coded knowledge skills are not present. 

